### PR TITLE
[JENKINS-39612] Update to 2.17 parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>1.580.1</version>
+    <version>2.17</version>
     <relativePath />
   </parent>
   <artifactId>variant</artifactId>
@@ -63,4 +63,8 @@
         </plugin>
       </plugins>
     </build>
+  <properties>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
+  </properties>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/variant/OptionalExtensionProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/variant/OptionalExtensionProcessor.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.variant;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionFinder.GuiceExtensionAnnotation;
 import hudson.PluginWrapper;
@@ -39,7 +40,7 @@ public class OptionalExtensionProcessor extends GuiceExtensionAnnotation<Optiona
     }
 
     /**
-     * Go up the scope chain (method > class > package > ...)
+     * Go up the scope chain (method &gt; class &gt; package &gt; ...)
      * and make sure any {@link OptionalExtension}s we encounter
      * are satisified.
      */
@@ -74,6 +75,7 @@ public class OptionalExtensionProcessor extends GuiceExtensionAnnotation<Optiona
         return true;
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     // this function and isActive(OptionalPackage) should be kept identical
     private boolean isActive(OptionalExtension a) {
         try {
@@ -97,6 +99,7 @@ public class OptionalExtensionProcessor extends GuiceExtensionAnnotation<Optiona
         return true;
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     // this function and isActive(OptionalExtension) should be kept identical
     private boolean isActive(OptionalPackage a) {
         try {


### PR DESCRIPTION
[JENKINS-39612](https://issues.jenkins-ci.org/browse/JENKINS-39612)

- Upgrade to 2.17 parent POM.
- Remove Javadoc and FindBugs errors.

@reviewbybees 