### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>2.36</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
   <artifactId>variant</artifactId>
@@ -71,7 +71,7 @@
       </plugins>
     </build>
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 </project>


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 