### PR TITLE
Exclude symbol-annotations as it's coming from the core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
       <version>2.1.10</version>
       <type>hpi</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- coming from the core anyway -->
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>symbol-annotation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
  <build>


### PR DESCRIPTION
Without this, *when* bumping credentials to 2.3.14 e.g. this breaks:

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (display-info) @ variant ---
[INFO] Adding ignore: module-info
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.jenkins-ci:symbol-annotation:1.1 paths to dependency are:
+-org.jenkins-ci.plugins:variant:1.4-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.249.1
    +-org.jenkins-ci:symbol-annotation:1.1
and
+-org.jenkins-ci.plugins:variant:1.4-SNAPSHOT
  +-org.jenkins-ci.plugins:credentials:2.3.14
    +-org.jenkins-ci.plugins:structs:1.20
      +-org.jenkins-ci:symbol-annotation:1.20
```


This is needed by https://github.com/jenkinsci/variant-plugin/pull/13