### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/variant/VariantTest.java
+++ b/src/test/java/org/jenkinsci/plugins/variant/VariantTest.java
@@ -4,37 +4,39 @@ import hudson.model.Action;
 import org.jenkinsci.plugins.variant.pkg.Negative5;
 import org.jenkinsci.plugins.variant.pkg.Positive5;
 import org.jenkinsci.plugins.variant.pkg2.Negative6;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * @author Kohsuke Kawaguchi
  */
-public class VariantTest extends Assert {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class VariantTest {
 
-    @BeforeClass
-    public static void setUp() {
+    @BeforeAll
+    static void setUp() {
         VariantSet.INSTANCE = new VariantSet("test");
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         VariantSet.INSTANCE = new VariantSet();
     }
 
     @Test
-    public void test() {
-        List<Class> classes = new ArrayList<Class>();
+    void test(JenkinsRule j) {
+        List<Class<?>> classes = new ArrayList<>();
         for (Action a : j.jenkins.getActions()) {
             classes.add(a.getClass());
         }
@@ -42,25 +44,24 @@ public class VariantTest extends Assert {
         assertTrue(classes.contains(Positive2.class));
         assertTrue(classes.contains(Positive3.class));
         assertTrue(classes.contains(Positive5.class));
-        assertTrue(!classes.contains(Negative1.class));
-        assertTrue(!classes.contains(Negative2.class));
-        assertTrue(!classes.contains(Negative5.class));
-        assertTrue(!classes.contains(Negative6.class));
+	    assertFalse(classes.contains(Negative1.class));
+	    assertFalse(classes.contains(Negative2.class));
+	    assertFalse(classes.contains(Negative5.class));
+	    assertFalse(classes.contains(Negative6.class));
     }
 
     @Test
     @Issue("JENKINS-37317")
-    public void testRequiredClass() {
-        List<Class> classes = new ArrayList<Class>();
+    void testRequiredClass(JenkinsRule j) {
+        List<Class<?>> classes = new ArrayList<>();
         for (Action a : j.jenkins.getActions()) {
             classes.add(a.getClass());
         }
-        assertTrue("Negative 3 should not exist", !classes.contains(Negative3.class));
+	    assertFalse(classes.contains(Negative3.class), "Negative 3 should not exist");
 
-        for (Class klass : classes) {
+        for (Class<?> klass : classes) {
             System.out.println(klass.getCanonicalName());
-            assertTrue("Negative 4 should not exist",
-                    !klass.getCanonicalName().equals("org.jenkinsci.plugins.variant.Negative4"));
+	        assertNotEquals("org.jenkinsci.plugins.variant.Negative4", klass.getCanonicalName(), "Negative 4 should not exist");
         }
 
         assertTrue(classes.contains(Positive4.class));


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I also took the freedom of re-enabling `ThrottleConcurrentTest` and refactor it to no longer rely on `jgiven`. 
IMHO there is no need for this test in particualar to use it and its better to streamline it with other tests in this plugin.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
